### PR TITLE
Category backend

### DIFF
--- a/app/models/tour.rb
+++ b/app/models/tour.rb
@@ -1,6 +1,13 @@
 class Tour < ApplicationRecord
   belongs_to :user
 
-  CATEGORYS=["walk", "food", "beer", "boat", "bike"]
-  validates :category, inclusion: { in: CATEGORYS }
+  # CATEGORYS=["walk", "food", "beer", "boat", "bike"] # old
+  CATEGORYS = {
+    walk: "fas fa-walking",
+    food: "fas fa-beer",
+    beer: "fas fa-bicycle",
+    boat: "fas fa-ship",
+    bike: "fas fa-utensils"
+  }
+  validates :category, inclusion: { in: CATEGORYS.keys.map(&:to_s) }
 end

--- a/app/models/tour.rb
+++ b/app/models/tour.rb
@@ -2,4 +2,5 @@ class Tour < ApplicationRecord
   belongs_to :user
 
   CATEGORYS=["walk", "food", "beer", "boat", "bike"]
+  validates :category, inclusion: { in: CATEGORYS }
 end

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,7 +1,7 @@
 <%= render 'banner' %>
 
 <div class="category-container">
-  <% Tour::CATEGORYS.each do |cat| %>
+  <% Tour::CATEGORYS.each do |cat, icon| %>
     <%= link_to tours_path(:category => cat), class: "cat-link" do %>
       <div class="category"><%= cat %></div>
     <% end %>

--- a/app/views/tours/new.html.erb
+++ b/app/views/tours/new.html.erb
@@ -12,7 +12,7 @@
           <%= f.text_field :description, class: 'form-control' %>
           <%= f.label :capacity %>
           <%= f.number_field :capacity, class: 'form-control' %>
-          <%= f.input :category, collection: Tour::CATEGORYS %>
+          <%= f.input :category, collection: Tour::CATEGORYS.keys.map(&:to_s) %>
           <%= f.label :location %>
           <%= f.text_field :location, class: 'form-control' %>
           <%= f.label :price_euro %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,15 +1,16 @@
 puts "seeding..."
 
 #TODO: date/time stuff
-#TODO: users
 
+puts "destroy tours and users..."
 Tour.destroy_all
 User.destroy_all
 
+puts "create users..."
 user = User.create!(email: 'test@test.com', password: 'password', password_confirmation: 'password')
+user2 = User.create!(email: 't@t.nl', password: 'password', password_confirmation: 'password')
 
-
-
+puts "create tours..."
 Tour.create!([
   {
     title: "fancy food in ams",
@@ -44,6 +45,39 @@ Tour.create!([
     price_euro: 20,
     user_id: user.id
   },
+  {
+    title: "chill boat tour",
+    description: "Some nice shippy bippy in ze river",
+    capacity: 10,
+    category: "boat",
+    longitude: 52.376198,
+    latitude: 4.893237,
+    location: "amsterdam",
+    price_euro: 20,
+    user_id: user.id
+  },
+  {
+    title: "Walk and talk",
+    description: "Sniff some fresh air in the forests",
+    capacity: 15,
+    category: "walk",
+    longitude: 52.376182,
+    latitude: 4.893267,
+    location: "amsterdam",
+    price_euro: 1,
+    user_id: user.id
+  },
+  {
+    title: "Jungle adventure in ams",
+    description: "Snakes and dirt",
+    capacity: 8,
+    category: "walk",
+    longitude: 52.376182,
+    latitude: 4.893167,
+    location: "amsterdam",
+    price_euro: 22,
+    user_id: user2.id
+  }
 ])
 
 


### PR DESCRIPTION
The old CATEGORY array got upgraded to an hash.
Old:
```
CATEGORYS=["walk", "food", "beer", "boat", "bike"] # old
```
New:
```
  CATEGORYS = {
    walk: "fas fa-walking",
    food: "fas fa-beer",
    beer: "fas fa-bicycle",
    boat: "fas fa-ship",
    bike: "fas fa-utensils"
  }
```

To use the old string array that holds the category names (also used for validation) use this code:
```
CATEGORYS.keys.map(&:to_s)
```