### PR TITLE
List all tours when no filter provided

### DIFF
--- a/app/controllers/tours_controller.rb
+++ b/app/controllers/tours_controller.rb
@@ -2,7 +2,11 @@ class ToursController < ApplicationController
   skip_before_action :authenticate_user!, only: [:index, :show]
 
   def index
-    @tours = policy_scope(Tour).where(category: params[:category])
+    if params[:category]
+      @tours = policy_scope(Tour).where(category: params[:category])
+    else
+      @tours = policy_scope(Tour)
+    end
   end
 
   def show


### PR DESCRIPTION
The filter introduced a bug that no tour was shown when no filter is provided ( for example when clicking on tours in the navbar ).

This pr fixes this.